### PR TITLE
Add API method for adding a custom activity to a lead

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -836,7 +836,7 @@ class Client extends GuzzleClient
         $args['input'] = [];
         foreach ($activities as $activity) {
             // Validation: Required parameters.
-            foreach (['id', 'leadId', 'primaryAttributeValue', 'activityTypeId'] as $required) {
+            foreach (['leadId', 'activityTypeId', 'primaryAttributeValue'] as $required) {
                 if (!isset($activity[$required])) {
                     throw new \InvalidArgumentException("Required parameter \"{$required}\" is missing.");
                 }
@@ -851,11 +851,10 @@ class Client extends GuzzleClient
 
             // Format required parameters
             $input = [
-                'id' => (int) $activity['id'], // Custom activity id
                 'leadId' => (int) $activity['leadId'],
+                'activityTypeId' => (int) $activity['activityTypeId'],
                 'primaryAttributeValue' => (string) $activity['primaryAttributeValue'],
                 'activityDate' => $activity['activityDate']->format('c'),
-                'activityTypeId' => (int) $activity['activityTypeId'],
             ];
 
             // Optional parameters

--- a/src/Client.php
+++ b/src/Client.php
@@ -12,6 +12,7 @@ namespace CSD\Marketo;
 
 // Guzzle
 use CommerceGuys\Guzzle\Plugin\Oauth2\Oauth2Plugin;
+use CSD\Marketo\Response\AddCustomActivitiesResponse;
 use CSD\Marketo\Response\GetLeadChanges;
 use CSD\Marketo\Response\GetPagingToken;
 use Guzzle\Common\Collection;
@@ -821,15 +822,43 @@ class Client extends GuzzleClient
     }
 
     /**
-     * Add 1+ custom activities.
+     * Add 1+ custom activities to a lead. Each activity added may be for the same or different lead.
      *
      * @see http://developers.marketo.com/rest-api/lead-database/activities/
      * @see http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#/Activities/addCustomActivityUsingPOST
      *
+     * @example: Here's some examples of what the $activities parameter may look like:
+     * $activities = [
+     *     [ // Example of minimum set of attributes for an activity
+     *         'leadId' => 4,
+     *         'activityTypeId' => 100002, // Created ahead of time in Marketo Portal Admin
+     *         'primaryAttributeValue' => 'FooBar',
+     *     ],
+     *     [ // Example of all optional attributes used
+     *         'leadId' => 6,
+     *         'activityTypeId' => 100003, // Created ahead of time in Marketo Portal Admin
+     *         'primaryAttributeValue' => 42,
+     *         'activityDate' => new \DateTime('+1 day'),
+     *         'apiName' => 'FooBar',
+     *         'status' => 'updated',
+     *         'attributes' => [
+     *             [
+     *                 'name' => 'quantity',
+     *                 'value' => 3,
+     *             ],
+     *             [
+     *                 'name' => 'price',
+     *                 'value' => 123.45,
+     *                 'apiName' => 'FooBar',
+     *             ]
+     *         ]
+     *     ],
+     * ];
+     *
      * @param array $activities Array of arrays.
      * @param array $args
      * @param bool $returnRaw
-     * @return Response|string
+     * @return AddCustomActivitiesResponse
      */
     public function addCustomActivities($activities, $args = array(), $returnRaw = false)
     {

--- a/src/Response/AddCustomActivitiesResponse.php
+++ b/src/Response/AddCustomActivitiesResponse.php
@@ -19,7 +19,7 @@ use CSD\Marketo\Response as Response;
 class AddCustomActivitiesResponse extends Response
 {
     /**
-     * Get the status of a lead.
+     * Get the status of the custom activity. If no custom activity ID is given, it returns the status of the first one.
      *
      * @param $id
      * @return bool
@@ -27,6 +27,11 @@ class AddCustomActivitiesResponse extends Response
     public function getStatus($id)
     {
         if ($this->isSuccess()) {
+            if (!$id) {
+                $result = $this->getResult();
+                return $result[0]['status'];
+            }
+
             foreach ($this->getResult() as $row) {
                 if ($row['id'] == $id) {
                     return $row['status'];

--- a/src/Response/AddCustomActivitiesResponse.php
+++ b/src/Response/AddCustomActivitiesResponse.php
@@ -21,13 +21,13 @@ class AddCustomActivitiesResponse extends Response
     /**
      * Get the status of the custom activity. If no custom activity ID is given, it returns the status of the first one.
      *
-     * @param $id
+     * @param int|null $id
      * @return bool
      */
-    public function getStatus($id)
+    public function getStatus($id = null)
     {
         if ($this->isSuccess()) {
-            if (!$id) {
+            if (is_null($id)) {
                 $result = $this->getResult();
                 return $result[0]['status'];
             }

--- a/src/Response/AddCustomActivitiesResponse.php
+++ b/src/Response/AddCustomActivitiesResponse.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * This file is part of the Marketo REST API Client package.
+ *
+ * (c) 2014 Daniel Chesterton
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CSD\Marketo\Response;
+
+use CSD\Marketo\Response as Response;
+
+/**
+ * Response for the addCustomActivities API method.
+ *
+ */
+class AddCustomActivitiesResponse extends Response
+{
+    /**
+     * Get the status of a lead.
+     *
+     * @param $id
+     * @return bool
+     */
+    public function getStatus($id)
+    {
+        if ($this->isSuccess()) {
+            foreach ($this->getResult() as $row) {
+                if ($row['id'] == $id) {
+                    return $row['status'];
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/service.json
+++ b/src/service.json
@@ -198,7 +198,7 @@
             "httpMethod": "POST",
             "uri": "activities/external.json",
             "parameters": {
-                "input": {"location": "query"}
+                "input": {"location": "json"}
             },
             "responseClass": "CSD\\Marketo\\Response\\AddCustomActivitiesResponse"
         },

--- a/src/service.json
+++ b/src/service.json
@@ -194,6 +194,14 @@
             },
             "responseClass": "CSD\\Marketo\\Response\\DeleteLeadResponse"
         },
+        "addCustomActivities": {
+            "httpMethod": "POST",
+            "uri": "activities/external.json",
+            "parameters": {
+                "input": {"location": "query"}
+            },
+            "responseClass": "CSD\\Marketo\\Response\\AddCustomActivitiesResponse"
+        },
         "getPagingToken": {
             "httpMethod": "GET",
             "uri": "activities/pagingtoken.json",


### PR DESCRIPTION
Adding support for the Marketo API method for adding custom activities to a lead.

This merge request is related to Issue #15. My first attempt at a solution didn't work because I had a bug in my service.json and API request parameters. Works now! :)

Also, thanks for maintaining this Marketo REST API fork -- dchesterton's seem to be abandoned. If you want help maintaining this project just let me know.