### PR TITLE
Add support to create custom objects.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -391,6 +391,31 @@ class Client extends GuzzleClient
         return $this->getResult('createOrUpdateObject', $args, false, $returnRaw);
     }
 
+  /**
+   * Create the given custom objects.
+   *
+   * @param string      $objectName
+   * @param string      $action     Should be createOnly, updateOnly, or createOrUpdate.
+   * @param array       $records    Array of arrays.
+   * @param string      $dedupeBy
+   * @param array       $args
+   * @param bool|false  $returnRaw
+   * @throws \Exception
+   *
+   * @return GetLeadsResponse
+   */
+  public function createOrUpdateCustomObjects($objectName, $action, $records, $dedupeBy = NULL, $args = array(), $returnRaw = false) {
+    $args['customObjectName'] = $objectName;
+    $args['action'] = $action;
+    $args['input'] = $records;
+
+    if (isset($dedupeBy)) {
+      $args['dedupeBy'] = $dedupeBy;
+    }
+
+    return $this->getResult('createOrUpdateCustomObject', $args, false, $returnRaw);
+  }
+
     /**
      * Create the given leads.
      *

--- a/src/service.json
+++ b/src/service.json
@@ -298,6 +298,17 @@
             },
             "responseModel": "baseResponse",
             "responseClass": "CSD\\Marketo\\Response"
+        },
+        "createOrUpdateCustomObject": {
+            "httpMethod": "POST",
+            "uri": "/rest/v1/customobjects/{customObjectName}.json",
+            "parameters": {
+                "customObjectName": {"location": "uri"},
+                "action": {"location": "json"},
+                "input": {"location": "json"},
+                "dedupeBy": {"location": "json"}
+            },
+            "responseClass": "CSD\\Marketo\\Response\\GetCustomObjectsResponse"
         }
     },
     "models": {


### PR DESCRIPTION
The client is currently missing support for the [Custom Object API](http://developers.marketo.com/rest-api/lead-database/custom-objects/). This PR starts the process of incorporating that functionality by adding the endpoint and commands for creating and updating custom objects via the [appropriate endpoint](http://developers.marketo.com/rest-api/lead-database/custom-objects/#create_and_update).