### PR TITLE
Add Forms 2.0 Endpoint to API Client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -219,7 +219,7 @@ class Client extends GuzzleClient
    *
    * @link https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Leads/SubmitFormUsingPOST
    *
-   * @return CreateOrUpdateLeadsResponse
+   * @return Response
    */
   private function submitFormCommand($formId, $fields, $args, $returnRaw = false)
   {
@@ -437,7 +437,7 @@ class Client extends GuzzleClient
      *
      * @link http://developers.marketo.com/documentation/rest/createupdate-leads/
      *
-     * @return CreateOrUpdateLeadsResponse
+     * @return Response
      */
     public function submitMarketoForm($fields, $formId = null, $args = array())
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -210,7 +210,26 @@ class Client extends GuzzleClient
 
         return $this->getResult('createOrUpdateLeads', $args, false, $returnRaw);
     }
+    
+  /**
+   * Calls the submitForm command to submit a Forms 2.0 POST request.
+   *
+   * @param array  $fields
+   * @param string $formId
+   *
+   * @link https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Leads/SubmitFormUsingPOST
+   *
+   * @return CreateOrUpdateLeadsResponse
+   */
+  private function submitFormCommand($formId, $fields, $args, $returnRaw = false)
+  {
+    $args['input'] = $fields;
+    $args['formId'] = $formId;
 
+    return $this->getResult('submitFormRequest', $args, false, $returnRaw);
+  }
+
+    
     /**
      * Only update the given opportunity roles.
      *
@@ -408,6 +427,23 @@ class Client extends GuzzleClient
         return $this->createOrUpdateLeadsCommand('createOnly', $leads, $lookupField, $args);
     }
 
+    /**
+     * Create the given leads.
+     *
+     * @param array  $leads
+     * @param string $lookupField
+     * @param array  $args
+     * @see Client::createOrUpdateLeadsCommand()
+     *
+     * @link http://developers.marketo.com/documentation/rest/createupdate-leads/
+     *
+     * @return CreateOrUpdateLeadsResponse
+     */
+    public function submitMarketoForm($fields, $formId = null, $args = array())
+    {
+      return $this->submitFormCommand($fields, $formId, $args);
+    }
+    
     /**
      * Update the given leads, or create them if they do not exist.
      *

--- a/src/Client.php
+++ b/src/Client.php
@@ -215,7 +215,7 @@ class Client extends GuzzleClient
    * Calls the submitForm command to submit a Forms 2.0 POST request.
    *
    * @param array  $fields
-   * @param string $formId
+   * @param int $formId
    *
    * @link https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Leads/SubmitFormUsingPOST
    *
@@ -426,16 +426,14 @@ class Client extends GuzzleClient
     {
         return $this->createOrUpdateLeadsCommand('createOnly', $leads, $lookupField, $args);
     }
-
+    
     /**
-     * Create the given leads.
+     * Submit a Forms 2.0 form
      *
-     * @param array  $leads
-     * @param string $lookupField
+     * @param array  $fields
+     * @param int $formId
      * @param array  $args
-     * @see Client::createOrUpdateLeadsCommand()
-     *
-     * @link http://developers.marketo.com/documentation/rest/createupdate-leads/
+     * @see Client::submitFormCommand()
      *
      * @return Response
      */

--- a/src/service.json
+++ b/src/service.json
@@ -157,6 +157,15 @@
             },
             "responseClass": "CSD\\Marketo\\Response\\CreateOrUpdateLeadsResponse"
         },
+        "submitFormRequest": {
+          "httpMethod": "POST",
+          "uri": "leads/submitForm.json",
+          "parameters": {
+            "input": {"location": "json"},
+            "formId": {"location": "json"}
+          },
+          "responseClass": "CSD\\Marketo\\Response"
+        },        
         "addLeadsToList": {
             "httpMethod": "POST",
             "uri": "lists/{listId}/leads.json",


### PR DESCRIPTION
This adds in a Response and Command to support submitting data to the new /rest/v1/leads/submitForm.json endpoint for Forms 2.0 submissions.